### PR TITLE
Display the default values next to the edit control. Fixes #3458.

### DIFF
--- a/GitCommands/Git/GitModule.cs
+++ b/GitCommands/Git/GitModule.cs
@@ -783,7 +783,7 @@ namespace GitCommands
             using (var ms = (MemoryStream)GetFileStream(blob)) //Ugly, has implementation info.
             {
                 byte[] buf = ms.ToArray();
-                if (EffectiveConfigFile.core.autocrlf.Value == AutoCRLFType.@true)
+                if (EffectiveConfigFile.core.autocrlf.ValueOrDefault == AutoCRLFType.@true)
                 {
                     if (!FileHelper.IsBinaryFile(this, saveAs) && !FileHelper.IsBinaryFileAccordingToContent(buf))
                     {

--- a/GitCommands/Patch/PatchManager.cs
+++ b/GitCommands/Patch/PatchManager.cs
@@ -37,7 +37,7 @@ namespace PatchApply
 
             //git apply has problem with dealing with autocrlf
             //I noticed that patch applies when '\r' chars are removed from patch if autocrlf is set to true
-            if (body != null && module.EffectiveConfigFile.core.autocrlf.Value == AutoCRLFType.@true)
+            if (body != null && module.EffectiveConfigFile.core.autocrlf.ValueOrDefault == AutoCRLFType.@true)
                 body = body.Replace("\r", "");
 
             if (header == null || body == null)
@@ -120,7 +120,7 @@ namespace PatchApply
             string body = selectedChunks.ToStagePatch(false, true);
             //git apply has problem with dealing with autocrlf
             //I noticed that patch applies when '\r' chars are removed from patch if autocrlf is set to true
-            if (reset && body != null && module.EffectiveConfigFile.core.autocrlf.Value == AutoCRLFType.@true)
+            if (reset && body != null && module.EffectiveConfigFile.core.autocrlf.ValueOrDefault == AutoCRLFType.@true)
                 body = body.Replace("\r", "");
 
             if (header == null || body == null)

--- a/GitCommands/Settings/BasicSettingTypes.cs
+++ b/GitCommands/Settings/BasicSettingTypes.cs
@@ -14,7 +14,7 @@ namespace GitCommands.Settings
         {
             get
             {
-                return SettingsSource.GetString(Name, DefaultValue);
+                return SettingsSource.GetString(Name, null);
             }
 
             set
@@ -43,17 +43,13 @@ namespace GitCommands.Settings
             }
         }
 
-        public bool ValueOrDefault
+        public new bool ValueOrDefault
         {
             get
             {
-                if (Value.HasValue)
-                    return Value.Value;
-
-                return DefaultValue.Value;
+                return base.ValueOrDefault.Value;
             }
         }
-
     }
 
     public class BoolSetting : Setting<bool>

--- a/GitCommands/Settings/RepoDistSettings.cs
+++ b/GitCommands/Settings/RepoDistSettings.cs
@@ -130,7 +130,7 @@ namespace GitCommands.Settings
         {
             get
             {
-                return new SettingsPath(this, Type.Value);
+                return new SettingsPath(this, Type.ValueOrDefault);
             }
         }
     }

--- a/GitCommands/Settings/Setting.cs
+++ b/GitCommands/Settings/Setting.cs
@@ -21,6 +21,27 @@ namespace GitCommands.Settings
 
         public abstract T Value { get; set; }
 
+        public T ValueOrDefault
+        {
+            get
+            {
+                T v = Value;
+                if (ValueIsEmpty(v))
+                {
+                    return DefaultValue;
+                }
+                else
+                {
+                    return v;
+                }
+            }
+        }
+
+        public virtual bool ValueIsEmpty(T aValue)
+        {
+            return EqualityComparer<T>.Default.Equals(aValue, default(T));
+        }
+
         public string FullPath
         {
             get

--- a/GitUI/BuildServerIntegration/BuildServerWatcher.cs
+++ b/GitUI/BuildServerIntegration/BuildServerWatcher.cs
@@ -278,7 +278,7 @@ namespace GitUI.BuildServerIntegration
             {
                 if (!Module.EffectiveSettings.BuildServer.EnableIntegration.ValueOrDefault)
                     return null;
-                var buildServerType = Module.EffectiveSettings.BuildServer.Type.Value;
+                var buildServerType = Module.EffectiveSettings.BuildServer.Type.ValueOrDefault;
                 if (string.IsNullOrEmpty(buildServerType))
                     return null;
                 var exports = ManagedExtensibility.GetExports<IBuildServerAdapter, IBuildServerTypeMetadata>();

--- a/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/GitUI/CommandsDialogs/FormBrowse.cs
@@ -3568,10 +3568,10 @@ namespace GitUI.CommandsDialogs
                 };
 
                 var startinfoBaseConfiguration = startinfo.BaseConfiguration;
-                if (!string.IsNullOrWhiteSpace(Module.EffectiveSettings.Detailed.ConEmuFontSize.Value))
+                if (!string.IsNullOrWhiteSpace(Module.EffectiveSettings.Detailed.ConEmuFontSize.ValueOrDefault))
                 {
                     int fontSize;
-                    if (int.TryParse(Module.EffectiveSettings.Detailed.ConEmuFontSize.Value, out fontSize))
+                    if (int.TryParse(Module.EffectiveSettings.Detailed.ConEmuFontSize.ValueOrDefault, out fontSize))
                     {
                         var nodeFontSize =
                             startinfoBaseConfiguration.SelectSingleNode("/key/key/key/value[@name='FontSize']");
@@ -3582,7 +3582,7 @@ namespace GitUI.CommandsDialogs
                 startinfo.BaseConfiguration = startinfoBaseConfiguration;
 
                 string[] exeList;
-                switch (Module.EffectiveSettings.Detailed.ConEmuTerminal.Value)
+                switch (Module.EffectiveSettings.Detailed.ConEmuTerminal.ValueOrDefault)
                 {
                     case "cmd":
                         exeList = new[] { "cmd.exe" };
@@ -3613,15 +3613,15 @@ namespace GitUI.CommandsDialogs
                 }
                 else
                 {
-                    if(Module.EffectiveSettings.Detailed.ConEmuTerminal.Value == "bash")
+                    if(Module.EffectiveSettings.Detailed.ConEmuTerminal.ValueOrDefault == "bash")
                         startinfo.ConsoleProcessCommandLine = cmdPath + " --login -i";
                     else
                         startinfo.ConsoleProcessCommandLine = cmdPath;
                 }
 
-                if (Module.EffectiveSettings.Detailed.ConEmuStyle.Value != "Default")
+                if (Module.EffectiveSettings.Detailed.ConEmuStyle.ValueOrDefault != "Default")
                 {
-                    startinfo.ConsoleProcessExtraArgs = " -new_console:P:\"" + Module.EffectiveSettings.Detailed.ConEmuStyle.Value + "\"";
+                    startinfo.ConsoleProcessExtraArgs = " -new_console:P:\"" + Module.EffectiveSettings.Detailed.ConEmuStyle.ValueOrDefault + "\"";
                 }
 
                 // Set path to git in this window (actually, effective with CMD only)
@@ -3641,7 +3641,7 @@ namespace GitUI.CommandsDialogs
             if (terminal == null || terminal.RunningSession == null || string.IsNullOrWhiteSpace(path))
                 return;
 
-            if (Module.EffectiveSettings.Detailed.ConEmuTerminal.Value == "bash")
+            if (Module.EffectiveSettings.Detailed.ConEmuTerminal.ValueOrDefault == "bash")
             {
                 string posixPath;
                 if (PathUtil.TryConvertWindowsPathToPosix(path, out posixPath))
@@ -3649,7 +3649,7 @@ namespace GitUI.CommandsDialogs
                     ClearTerminalCommandLineAndRunCommand("cd " + posixPath);
                 }
             }
-            else if (Module.EffectiveSettings.Detailed.ConEmuTerminal.Value == "powershell")
+            else if (Module.EffectiveSettings.Detailed.ConEmuTerminal.ValueOrDefault == "powershell")
             {
                 ClearTerminalCommandLineAndRunCommand("cd \"" + path + "\"");
             }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/BuildServerIntegrationSettingsPage.cs
@@ -61,8 +61,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             _populateBuildServerTypeTask.ContinueWith(
                 task =>
                 {
-                    checkBoxEnableBuildServerIntegration.SetNullableChecked(CurrentSettings.BuildServer.EnableIntegration.Value);
-                    checkBoxShowBuildSummary.SetNullableChecked(CurrentSettings.BuildServer.ShowBuildSummaryInGrid.Value);
+                    checkBoxEnableBuildServerIntegration.SetNullableChecked((bool?)CurrentSettings.BuildServer.EnableIntegration.Value);
+                    checkBoxShowBuildSummary.SetNullableChecked((bool?)CurrentSettings.BuildServer.ShowBuildSummaryInGrid.Value);
 
                     BuildServerType.SelectedItem = CurrentSettings.BuildServer.Type.Value ?? _noneItem.Text;
                 },

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.Designer.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.Designer.cs
@@ -42,6 +42,9 @@
             this.cboStyle = new System.Windows.Forms.ComboBox();
             this.chkChowConsoleTab = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this._NO_TRANSLATE_consolStyleDefaultLable = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_ShellToRunLabelDefault = new System.Windows.Forms.Label();
+            this._NO_TRANSLATE_FontSizeDefault = new System.Windows.Forms.Label();
             this.PushWindowGB.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             this.BrowseRepoGB.SuspendLayout();
@@ -56,11 +59,10 @@
             this.PushWindowGB.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.PushWindowGB.Controls.Add(this.tableLayoutPanel1);
             this.PushWindowGB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.PushWindowGB.Location = new System.Drawing.Point(3, 243);
-            this.PushWindowGB.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.PushWindowGB.Location = new System.Drawing.Point(3, 198);
             this.PushWindowGB.Name = "PushWindowGB";
-            this.PushWindowGB.Padding = new System.Windows.Forms.Padding(9, 10, 9, 10);
-            this.PushWindowGB.Size = new System.Drawing.Size(1258, 65);
+            this.PushWindowGB.Padding = new System.Windows.Forms.Padding(8, 8, 8, 8);
+            this.PushWindowGB.Size = new System.Drawing.Size(1496, 53);
             this.PushWindowGB.TabIndex = 1;
             this.PushWindowGB.TabStop = false;
             this.PushWindowGB.Text = "Push window";
@@ -73,8 +75,7 @@
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Controls.Add(this.chkRemotesFromServer, 0, 4);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(9, 26);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(8, 22);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 6;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -83,7 +84,7 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1240, 29);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1480, 23);
             this.tableLayoutPanel1.TabIndex = 1;
             // 
             // chkRemotesFromServer
@@ -91,10 +92,9 @@
             this.chkRemotesFromServer.AutoSize = true;
             this.chkRemotesFromServer.Cursor = System.Windows.Forms.Cursors.Arrow;
             this.chkRemotesFromServer.Dock = System.Windows.Forms.DockStyle.Top;
-            this.chkRemotesFromServer.Location = new System.Drawing.Point(3, 4);
-            this.chkRemotesFromServer.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkRemotesFromServer.Location = new System.Drawing.Point(3, 3);
             this.chkRemotesFromServer.Name = "chkRemotesFromServer";
-            this.chkRemotesFromServer.Size = new System.Drawing.Size(1234, 21);
+            this.chkRemotesFromServer.Size = new System.Drawing.Size(1474, 17);
             this.chkRemotesFromServer.TabIndex = 4;
             this.chkRemotesFromServer.Text = "Get remote branches directly from the remote";
             this.chkRemotesFromServer.UseVisualStyleBackColor = true;
@@ -105,11 +105,10 @@
             this.BrowseRepoGB.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.BrowseRepoGB.Controls.Add(this.tableLayoutPanel3);
             this.BrowseRepoGB.Dock = System.Windows.Forms.DockStyle.Top;
-            this.BrowseRepoGB.Location = new System.Drawing.Point(3, 4);
-            this.BrowseRepoGB.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.BrowseRepoGB.Location = new System.Drawing.Point(3, 3);
             this.BrowseRepoGB.Name = "BrowseRepoGB";
-            this.BrowseRepoGB.Padding = new System.Windows.Forms.Padding(9, 10, 9, 10);
-            this.BrowseRepoGB.Size = new System.Drawing.Size(1258, 231);
+            this.BrowseRepoGB.Padding = new System.Windows.Forms.Padding(8, 8, 8, 8);
+            this.BrowseRepoGB.Size = new System.Drawing.Size(1496, 189);
             this.BrowseRepoGB.TabIndex = 0;
             this.BrowseRepoGB.TabStop = false;
             this.BrowseRepoGB.Text = "Browse repository window";
@@ -123,13 +122,12 @@
             this.tableLayoutPanel3.Controls.Add(this.groupBoxConsoleSettings, 0, 1);
             this.tableLayoutPanel3.Controls.Add(this.chkChowConsoleTab, 0, 0);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(9, 26);
-            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(8, 22);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 2;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(1240, 195);
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(1480, 159);
             this.tableLayoutPanel3.TabIndex = 1;
             // 
             // groupBoxConsoleSettings
@@ -137,16 +135,20 @@
             this.groupBoxConsoleSettings.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBoxConsoleSettings.AutoSize = true;
+            this.groupBoxConsoleSettings.Controls.Add(this._NO_TRANSLATE_FontSizeDefault);
+            this.groupBoxConsoleSettings.Controls.Add(this._NO_TRANSLATE_ShellToRunLabelDefault);
+            this.groupBoxConsoleSettings.Controls.Add(this._NO_TRANSLATE_consolStyleDefaultLable);
             this.groupBoxConsoleSettings.Controls.Add(this.label3);
             this.groupBoxConsoleSettings.Controls.Add(this.cboFontSize);
             this.groupBoxConsoleSettings.Controls.Add(this.label2);
             this.groupBoxConsoleSettings.Controls.Add(this.label1);
             this.groupBoxConsoleSettings.Controls.Add(this.cboTerminal);
             this.groupBoxConsoleSettings.Controls.Add(this.cboStyle);
-            this.groupBoxConsoleSettings.Location = new System.Drawing.Point(20, 32);
-            this.groupBoxConsoleSettings.Margin = new System.Windows.Forms.Padding(20, 3, 3, 3);
+            this.groupBoxConsoleSettings.Location = new System.Drawing.Point(17, 25);
+            this.groupBoxConsoleSettings.Margin = new System.Windows.Forms.Padding(17, 2, 3, 2);
             this.groupBoxConsoleSettings.Name = "groupBoxConsoleSettings";
-            this.groupBoxConsoleSettings.Size = new System.Drawing.Size(1217, 160);
+            this.groupBoxConsoleSettings.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.groupBoxConsoleSettings.Size = new System.Drawing.Size(1460, 132);
             this.groupBoxConsoleSettings.TabIndex = 3;
             this.groupBoxConsoleSettings.TabStop = false;
             this.groupBoxConsoleSettings.Text = "Console settings (a restart is needed to take effect)";
@@ -154,9 +156,9 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(6, 114);
+            this.label3.Location = new System.Drawing.Point(5, 93);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(61, 17);
+            this.label3.Size = new System.Drawing.Size(50, 13);
             this.label3.TabIndex = 7;
             this.label3.Text = "Font size";
             // 
@@ -176,26 +178,27 @@
             "19",
             "20",
             "24"});
-            this.cboFontSize.Location = new System.Drawing.Point(138, 114);
+            this.cboFontSize.Location = new System.Drawing.Point(118, 93);
+            this.cboFontSize.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cboFontSize.Name = "cboFontSize";
-            this.cboFontSize.Size = new System.Drawing.Size(305, 24);
+            this.cboFontSize.Size = new System.Drawing.Size(262, 21);
             this.cboFontSize.TabIndex = 6;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(6, 73);
+            this.label2.Location = new System.Drawing.Point(5, 59);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(77, 17);
+            this.label2.Size = new System.Drawing.Size(61, 13);
             this.label2.TabIndex = 5;
             this.label2.Text = "Shell to run";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 35);
+            this.label1.Location = new System.Drawing.Point(5, 28);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(88, 17);
+            this.label1.Size = new System.Drawing.Size(71, 13);
             this.label1.TabIndex = 5;
             this.label1.Text = "Console style";
             // 
@@ -207,9 +210,10 @@
             "bash",
             "cmd",
             "powershell"});
-            this.cboTerminal.Location = new System.Drawing.Point(138, 73);
+            this.cboTerminal.Location = new System.Drawing.Point(118, 59);
+            this.cboTerminal.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cboTerminal.Name = "cboTerminal";
-            this.cboTerminal.Size = new System.Drawing.Size(305, 24);
+            this.cboTerminal.Size = new System.Drawing.Size(262, 21);
             this.cboTerminal.TabIndex = 4;
             // 
             // cboStyle
@@ -244,18 +248,18 @@
             "<Ubuntu>",
             "<xterm>",
             "<Zenburn>"});
-            this.cboStyle.Location = new System.Drawing.Point(138, 32);
+            this.cboStyle.Location = new System.Drawing.Point(118, 26);
+            this.cboStyle.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cboStyle.Name = "cboStyle";
-            this.cboStyle.Size = new System.Drawing.Size(305, 24);
+            this.cboStyle.Size = new System.Drawing.Size(262, 21);
             this.cboStyle.TabIndex = 3;
             // 
             // chkChowConsoleTab
             // 
             this.chkChowConsoleTab.AutoSize = true;
-            this.chkChowConsoleTab.Location = new System.Drawing.Point(3, 4);
-            this.chkChowConsoleTab.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.chkChowConsoleTab.Location = new System.Drawing.Point(3, 3);
             this.chkChowConsoleTab.Name = "chkChowConsoleTab";
-            this.chkChowConsoleTab.Size = new System.Drawing.Size(164, 21);
+            this.chkChowConsoleTab.Size = new System.Drawing.Size(131, 17);
             this.chkChowConsoleTab.TabIndex = 0;
             this.chkChowConsoleTab.Text = "Show the Console tab";
             this.chkChowConsoleTab.UseVisualStyleBackColor = true;
@@ -271,23 +275,48 @@
             this.tableLayoutPanel2.Controls.Add(this.PushWindowGB, 0, 1);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 3;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(1264, 877);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(1502, 594);
             this.tableLayoutPanel2.TabIndex = 2;
+            // 
+            // _NO_TRANSLATE_consolStyleDefaultLable
+            // 
+            this._NO_TRANSLATE_consolStyleDefaultLable.AutoSize = true;
+            this._NO_TRANSLATE_consolStyleDefaultLable.Location = new System.Drawing.Point(386, 29);
+            this._NO_TRANSLATE_consolStyleDefaultLable.Name = "_NO_TRANSLATE_consolStyleDefaultLable";
+            this._NO_TRANSLATE_consolStyleDefaultLable.Size = new System.Drawing.Size(71, 13);
+            this._NO_TRANSLATE_consolStyleDefaultLable.TabIndex = 8;
+            this._NO_TRANSLATE_consolStyleDefaultLable.Text = "Console style";
+            // 
+            // _NO_TRANSLATE_ShellToRunLabelDefault
+            // 
+            this._NO_TRANSLATE_ShellToRunLabelDefault.AutoSize = true;
+            this._NO_TRANSLATE_ShellToRunLabelDefault.Location = new System.Drawing.Point(386, 62);
+            this._NO_TRANSLATE_ShellToRunLabelDefault.Name = "_NO_TRANSLATE_ShellToRunLabelDefault";
+            this._NO_TRANSLATE_ShellToRunLabelDefault.Size = new System.Drawing.Size(61, 13);
+            this._NO_TRANSLATE_ShellToRunLabelDefault.TabIndex = 9;
+            this._NO_TRANSLATE_ShellToRunLabelDefault.Text = "Shell to run";
+            // 
+            // _NO_TRANSLATE_FontSizeDefault
+            // 
+            this._NO_TRANSLATE_FontSizeDefault.AutoSize = true;
+            this._NO_TRANSLATE_FontSizeDefault.Location = new System.Drawing.Point(386, 96);
+            this._NO_TRANSLATE_FontSizeDefault.Name = "_NO_TRANSLATE_FontSizeDefault";
+            this._NO_TRANSLATE_FontSizeDefault.Size = new System.Drawing.Size(50, 13);
+            this._NO_TRANSLATE_FontSizeDefault.TabIndex = 10;
+            this._NO_TRANSLATE_FontSizeDefault.Text = "Font size";
             // 
             // DetailedSettingsPage
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.tableLayoutPanel2);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "DetailedSettingsPage";
-            this.Size = new System.Drawing.Size(1264, 877);
+            this.Size = new System.Drawing.Size(1502, 594);
             this.PushWindowGB.ResumeLayout(false);
             this.PushWindowGB.PerformLayout();
             this.tableLayoutPanel1.ResumeLayout(false);
@@ -321,5 +350,8 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.ComboBox cboFontSize;
+        private System.Windows.Forms.Label _NO_TRANSLATE_consolStyleDefaultLable;
+        private System.Windows.Forms.Label _NO_TRANSLATE_ShellToRunLabelDefault;
+        private System.Windows.Forms.Label _NO_TRANSLATE_FontSizeDefault;
     }
 }

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/DetailedSettingsPage.cs
@@ -1,4 +1,5 @@
-﻿using GitCommands.Settings;
+﻿using System;
+using GitCommands.Settings;
 
 namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 {
@@ -9,6 +10,20 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
             InitializeComponent();
             Text = "Detailed";
             Translate();
+        }
+
+        protected override void Init(ISettingsPageHost aPageHost)
+        {
+            base.Init(aPageHost);
+
+            AssignDefaultLabels();
+        }
+
+        private void AssignDefaultLabels()
+        {
+            _NO_TRANSLATE_consolStyleDefaultLable.Text = "(" + DetailedSettings.ConEmuStyle.DefaultValue + ")";
+            _NO_TRANSLATE_ShellToRunLabelDefault.Text = "(" + DetailedSettings.ConEmuTerminal.DefaultValue + ")";
+            _NO_TRANSLATE_FontSizeDefault.Text = "(" + DetailedSettings.ConEmuFontSize.DefaultValue + ")";
         }
 
         private DetailedGroup DetailedSettings
@@ -31,8 +46,8 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
         protected override void PageToSettings()
         {
             DetailedSettings.ShowConEmuTab.Value = chkChowConsoleTab.GetNullableChecked();
-            DetailedSettings.ConEmuStyle.Value = cboStyle.SelectedItem.ToString();
-            DetailedSettings.ConEmuTerminal.Value = cboTerminal.SelectedItem.ToString();
+            DetailedSettings.ConEmuStyle.Value = cboStyle.SelectedItem == null ? null : cboStyle.SelectedItem.ToString();
+            DetailedSettings.ConEmuTerminal.Value = cboTerminal.SelectedItem == null ? null : cboTerminal.SelectedItem.ToString();
             int newFontSize;
             if (int.TryParse(cboFontSize.Text, out newFontSize))
             {

--- a/GitUI/Editor/FileViewer.cs
+++ b/GitUI/Editor/FileViewer.cs
@@ -1043,7 +1043,7 @@ namespace GitUI.Editor
 
         private string DoAutoCRLF(string s)
         {
-            if (Module.EffectiveConfigFile.core.autocrlf.Value == AutoCRLFType.@true)
+            if (Module.EffectiveConfigFile.core.autocrlf.ValueOrDefault == AutoCRLFType.@true)
             {
                 return s.Replace("\n", Environment.NewLine);
             }


### PR DESCRIPTION
When control can not distinguish whether the default value is entered by an user or is populated with the default value for a setting then visiting the setting page results in overriding the existing empty value with the default value.