### PR TITLE
VSTS: Integrate plugin in the installer.

### DIFF
--- a/Setup/Product.wxs
+++ b/Setup/Product.wxs
@@ -301,6 +301,9 @@
       <Component Id="TfsInterop.Vs2015.dll" Guid="*">
         <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\$(var.Configuration)\TfsInterop.Vs2015.dll" />
       </Component>
+      <Component Id="VstsAndTfsIntegration.dll" Guid="*">
+        <File Source="..\Plugins\BuildServerIntegration\VstsAndTfsIntegration\bin\$(var.Configuration)\VstsAndTfsIntegration.dll" />
+      </Component>
       <Component Id="Microsoft.VisualStudio.Services.WebApi.dll" Guid="*">
         <File Source="..\Plugins\BuildServerIntegration\TfsInterop.Vs2015\bin\$(var.Configuration)\Microsoft.VisualStudio.Services.WebApi.dll" />
       </Component>
@@ -688,6 +691,10 @@
           <ComponentRef Id="Microsoft.VisualStudio.Services.Common.dll" />
           <ComponentRef Id="Microsoft.VisualStudio.Services.WebApi.dll" />
           <ComponentRef Id="System.Net.Http.Formatting.dll" />
+          <ComponentRef Id="Newtonsoft.Json.dll" />
+        </Feature>
+        <Feature Id="VstsAndTfsIntegration" Title="Vsts and Tfs >= 2015 integration" Level="1">
+          <ComponentRef Id="VstsAndTfsIntegration.dll" />
           <ComponentRef Id="Newtonsoft.Json.dll" />
         </Feature>
         <Feature Id="JiraCommitHintPlugin" Title="Jira Commit Hint Plugin" Level="1">


### PR DESCRIPTION
Addresses installer comment created in PR introducing support for VSTS builds.

Changes proposed in this pull request:
- Include the plugin assembly in GitExtensions installer
 
Screenshots before and after (if PR changes UI):
- N/A

What did I do to test the code and ensure quality:
- Run the installer and checked that plugin has been properly installed

Has been tested on (remove any that don't apply):
- GIT 2.17 and above
- Windows 10
