### PR TITLE
Remove the need of searching for project Id using the project name

### DIFF
--- a/Plugins/BuildServerIntegration/VstsAndTfsIntegration/TfsApiHelper.cs
+++ b/Plugins/BuildServerIntegration/VstsAndTfsIntegration/TfsApiHelper.cs
@@ -41,7 +41,7 @@ namespace VstsAndTfsIntegration
         {
             var buildDefs = new List<BuildDefinition>();
 
-            using (var response = await _httpClient.GetAsync($"_apis/build/definitions"))
+            using (var response = await _httpClient.GetAsync($"_apis/build/definitions?api-version=2.0"))
             {
                 response.EnsureSuccessStatusCode();
                 string json = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes issue when the targeted VSTS instance has lots of projects.

Changes proposed in this pull request:
- Instead of iterating over projects to find the project id, directly pass the project name in all cases, leaving the job of figuring out the actual project to VSTS. This spares at least one network request is all cases.
 
Screenshots before and after (if PR changes UI):
- N/A

What did I do to test the code and ensure quality:
- Tested against a VSTS instance with 100+ projects.

Has been tested on (remove any that don't apply):
- GIT 2.17
- Windows 10
